### PR TITLE
AIW-432: upgrade pillow and lxml requirements

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -25,6 +25,7 @@ jobs:
     - name: Slack Notify
       uses: ravsamhq/notify-slack-action@v1
       if: always()
+      continue-on-error: true
       with:
         status: ${{ job.status }}
       env:

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9","3.10","3.11","3.12"]
+        python-version: ["3.10","3.11","3.12","3.13"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -38,6 +38,7 @@ jobs:
     - name: Slack Notify
       uses: ravsamhq/notify-slack-action@v1
       if: always()
+      continue-on-error: true
       with:
         status: ${{ job.status }}
       env:

--- a/README.en.md
+++ b/README.en.md
@@ -120,10 +120,10 @@ Most of the scripts refer to the [examples](https://github.com/wkentaro/labelme/
 ### Installation
 
 #### install in develop mode
-1. suggested to use virtualenv to install python packages.
+1. suggested to use a Python 3.10 or newer virtualenv to install python packages.
   
     ```sh
-    conda create --name=labelme python=3.9
+    conda create --name=labelme python=3.10
     conda activate labelme
     pip install -r requirements.txt
     ```

--- a/README.md
+++ b/README.md
@@ -119,10 +119,10 @@
 3. 如果有转换标签的需求（比如中文标签转为英文），准备一个文本，包含转换的规则，举个例子，命名为`label_dict.txt`。可以参考下项目里的 `test/label_dict.txt` 。
 ### Installation
 #### develop mode 安装
-1. 建议使用虚拟环境安装 Python Package。
+1. 建议使用 Python 3.10 或更高版本的虚拟环境安装 Python Package。
   
     ```sh
-    conda create --name=labelme python=3.9
+    conda create --name=labelme python=3.10
     conda activate labelme
     pip install -r requirements.txt
     ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ progressbar~=2.5
 scikit-learn>=1.5.0
 xmltodict~=0.13.0
 setuptools>=78.1.1
-pillow~=10.3.0
-lxml~=5.2.1
+pillow>=12.1.1
+lxml>=6.1.0

--- a/setup.py
+++ b/setup.py
@@ -34,8 +34,8 @@ setup(
         'scikit-learn>=1.5.0',
         'xmltodict~=0.13.0',
         'setuptools>=78.1.1',
-        'pillow~=10.3.0',
-        'lxml~=5.2.1'
+        'pillow>=12.1.1',
+        'lxml>=6.1.0'
     ],
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
     url="https://github.com/veraposeidon/labelme2Datasets",
     author='veraposeidon',
     packages=find_packages(include=['labelme2datasets', 'labelme2datasets.*']),
+    python_requires='>=3.10',
     install_requires=[
         'beautifulsoup4~=4.12.3',
         'imgviz~=1.7.5',
@@ -46,7 +47,10 @@ setup(
         ]
     },
     classifiers=[
-        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],


### PR DESCRIPTION
## 变更内容

- 将 `requirements.txt` 中的 `pillow` 从 `~=10.3.0` 升级为 `>=12.1.1`。
- 将 `requirements.txt` 中的 `lxml` 从 `~=5.2.1` 升级为 `>=6.1.0`。
- 同步更新 `setup.py` 的 `install_requires`，避免可编辑安装仍解析到旧版依赖。
- 根据 owner 决策，将项目最低 Python 版本提升到 `>=3.10`：新增 `python_requires='>=3.10'`，更新 Python classifiers，更新中英文 README 安装说明。
- 更新 Pylint CI matrix：移除 Python 3.9，覆盖 Python 3.10/3.11/3.12/3.13。
- 将 Slack notification step 调整为 `continue-on-error: true`，避免第三方通知 action 故障阻塞核心 CI 质量门禁。

## 影响范围

- 影响本地开发安装、package metadata 依赖解析、PyPI metadata、README 安装指引和 GitHub Actions CI matrix。
- 未修改转换逻辑、CLI 参数或输出数据结构。

## 验证

本地验证：

- `python3 -m pip index versions pillow`：确认 `12.1.1` 可用。
- `python3 -m pip index versions lxml`：确认 `6.1.0` 可用。
- `.venv/bin/python -m pip install -r requirements.txt`：通过，实际安装 `pillow 12.2.0`、`lxml 6.1.1`。
- `.venv/bin/python -m pip install -e .`：通过，package metadata 使用新依赖约束。
- `.venv/bin/python -m pip check`：No broken requirements found。
- `.venv/bin/python -c "import importlib.metadata as m; print(m.metadata('labelme2datasets').get('Requires-Python'))"`：输出 `>=3.10`。
- `.venv/bin/pylint labelme2datasets/**`：通过，评分 `10.00/10`。
- 基本功能验证通过：`labelme_json2dataset`、`labelme_bbox_json2voc`、`split_voc_datasets`、`voc2coco`。

远端 CI：

- Pylint / `build (3.10)`：pass。
- Pylint / `build (3.11)`：pass。
- Pylint / `build (3.12)`：pass。
- Pylint / `build (3.13)`：pass。

## 风险点

- 合并后 Python 3.9 用户将无法继续安装新版包；这是本次安全升级目标版本的上游约束，已按 owner 确认接受。
- Dependabot/security alert 需要合并到默认分支后重新扫描才会关闭。

Closes AIW-432