### PR TITLE
AIW-433: prepare 0.0.4 patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.0.4 - 2026-07-01
+
+- Require Python 3.10 or later in package metadata.
+- Upgrade security-sensitive dependencies: `pillow>=12.1.1` and `lxml>=6.1.0`.
+- Refresh Python version classifiers for Python 3.10 through 3.13.

--- a/labelme2datasets/version.py
+++ b/labelme2datasets/version.py
@@ -2,4 +2,4 @@
 Version of labelme2datasets.
 """
 
-__version__ = "0.0.3"
+__version__ = "0.0.4"


### PR DESCRIPTION
## Summary
- Bump labelme2datasets package version to 0.0.4
- Add CHANGELOG entry for the Python >=3.10 metadata and pillow/lxml security dependency release

## Verification
- python -m build
- wheel METADATA check: Version 0.0.4, Requires-Python >=3.10, pillow>=12.1.1, lxml>=6.1.0
- pip install local wheel in a fresh Python 3.13 venv
- CLI smoke: labelme_json2dataset --help, labelme_bbox_json2voc --help, split_voc_datasets --help, voc2coco --help

## Release note
Publishing remains intentionally blocked pending owner confirmation because creating the GitHub Release/tag will trigger the PyPI publish workflow.